### PR TITLE
Update to nim 2 x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        nim: [1.6.20, stable]
+        nim: [2.0.12, stable]
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        nim: [2.0.12, stable]
+        nim: [2.0.14, stable]
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/eth_versioned.nimble
+++ b/eth_versioned.nimble
@@ -1,7 +1,7 @@
 # corresponds to what the dependent package version SHOULD BE, following the
 # [semver spec](http://semver.org/) [with initial release at
 # 1.0.0](https://docs.npmjs.com/about-semantic-versioning#incrementing-semantic-versions-in-published-packages).
-version = "1.0.0"
+version = "1.1.0"
 author = "Status Research & Development GmbH"
 description = "Ethereum Common library"
 license = "MIT"

--- a/eth_versioned.nimble
+++ b/eth_versioned.nimble
@@ -7,4 +7,4 @@ description = "Ethereum Common library"
 license = "MIT"
 
 requires "nim >= 1.6.0"
-requires "eth#c482b4c5b658a77cc96b49d4a397aa6d98472ac7"
+requires "eth >= 0.5.0"

--- a/eth_versioned.nimble
+++ b/eth_versioned.nimble
@@ -6,5 +6,5 @@ author = "Status Research & Development GmbH"
 description = "Ethereum Common library"
 license = "MIT"
 
-requires "nim >= 1.6.0"
+requires "nim >= 2.0.14"
 requires "eth >= 0.5.0"


### PR DESCRIPTION
This PR contains the changes to move to Nim 2.0.14

Note that nim-eth removed the support for Nim 1.6: https://github.com/status-im/nim-eth/commit/410eab5a16d60c93c7c5d46b61b0c0ccb558bfe9. 

So this PR does not aim to maintain support for Nim 1.6.